### PR TITLE
Remove steam key prerequisite

### DIFF
--- a/_posts/2019-09-10-guide_building_the_game.md
+++ b/_posts/2019-09-10-guide_building_the_game.md
@@ -14,8 +14,7 @@ This Guide covers the general method of building the latest code from GitHub for
 ## Prerequisites
 To make use of this page, you should:  
 - Be using the Administrator account of the machine you're using
-- Have Momentum activated on your Steam account
-- Have a pot of Coffee (optional)
+- Have a pot of coffee (optional)
 
 <div class="note info">
     <p>


### PR DESCRIPTION
The ***Important Note*** already says it and explains why, so it should not be in this list.
Also `Coffee` isn't a name in this context, so it's `coffee` from now on.