### PR TITLE
Added "requires mapping" metadata on zone vars/commands

### DIFF
--- a/_posts/con-commands/2020-05-01-mom_zone_back.md
+++ b/_posts/con-commands/2020-05-01-mom_zone_back.md
@@ -3,6 +3,7 @@ title: mom_zone_back
 category: command
 tags:
   - zones
+requires_mapping: true
 ---
 
 Goes back a step when zone building.

--- a/_posts/con-commands/2020-05-01-mom_zone_cancel.md
+++ b/_posts/con-commands/2020-05-01-mom_zone_cancel.md
@@ -3,6 +3,7 @@ title: mom_zone_cancel
 category: command
 tags:
   - zones
+requires_mapping: true
 ---
 
 Cancels the building of the current zone.

--- a/_posts/con-commands/2020-05-01-mom_zone_create.md
+++ b/_posts/con-commands/2020-05-01-mom_zone_create.md
@@ -3,6 +3,7 @@ title: mom_zone_create
 category: command
 tags:
   - zones
+requires_mapping: true
 ---
 
 Creates the zone that you are done building.

--- a/_posts/con-commands/2020-05-01-mom_zone_delete.md
+++ b/_posts/con-commands/2020-05-01-mom_zone_delete.md
@@ -6,6 +6,7 @@ tags:
   - trigger
 required_params: 
   - Entity index/Start/Stop/Stage/Checkpoint
+requires_mapping: true
 ---
 
 Deletes zone types. Accepts start/stop/stage/checkpoint or an entity index.

--- a/_posts/con-commands/2020-05-01-mom_zone_edit_existing.md
+++ b/_posts/con-commands/2020-05-01-mom_zone_edit_existing.md
@@ -6,6 +6,7 @@ tags:
   - trigger
 required_params: 
   - Entity index
+requires_mapping: true
 ---
 
 Edits an existing zone. Only accepts an entity index.

--- a/_posts/con-commands/2020-05-01-mom_zone_generate.md
+++ b/_posts/con-commands/2020-05-01-mom_zone_generate.md
@@ -3,6 +3,7 @@ title: mom_zone_generate
 category: command
 tags:
   - zones
+requires_mapping: true
 ---
 
 Generates the .zon file for map zones.

--- a/_posts/con-commands/2020-05-01-mom_zone_mark.md
+++ b/_posts/con-commands/2020-05-01-mom_zone_mark.md
@@ -3,6 +3,7 @@ title: mom_zone_mark
 category: command
 tags:
   - zones
+requires_mapping: true
 ---
 
 Starts building a zone.

--- a/_posts/con-commands/2020-05-01-mom_zone_showmenu.md
+++ b/_posts/con-commands/2020-05-01-mom_zone_showmenu.md
@@ -4,6 +4,7 @@ category: command
 tags:
   - zones
   - hud
+requires_mapping: true
 ---
 
 Shows the zoning menu.

--- a/_posts/con-commands/2020-05-01-mom_zone_start_setlook.md
+++ b/_posts/con-commands/2020-05-01-mom_zone_start_setlook.md
@@ -6,6 +6,7 @@ tags:
   - trigger
 optional_params:
   - Yaw in degrees
+requires_mapping: true
 ---
 
 Sets the angle the player is looking towards when teleporting to the start zone. Takes in yaw in degrees or uses your current looking angle.

--- a/_posts/con-commands/2020-05-01-mom_zone_zoomin.md
+++ b/_posts/con-commands/2020-05-01-mom_zone_zoomin.md
@@ -4,6 +4,7 @@ category: command
 tags:
   - zones
   - crosshair
+requires_mapping: true
 cvar_ref: mom_zone_grid
 ---
 

--- a/_posts/con-commands/2020-05-01-mom_zone_zoomout.md
+++ b/_posts/con-commands/2020-05-01-mom_zone_zoomout.md
@@ -4,6 +4,7 @@ category: command
 tags:
   - zones
   - crosshair
+requires_mapping: true
 cvar_ref: mom_zone_grid
 ---
 

--- a/_posts/convars/2020-04-30-mom_zone_auto_make_stage.md
+++ b/_posts/convars/2020-04-30-mom_zone_auto_make_stage.md
@@ -7,6 +7,7 @@ tags:
 minimum_value: 0
 maximum_value: 1
 default_value: 0
+requires_mapping: true
 cvar_ref: mom_zone_type
 ---
 

--- a/_posts/convars/2020-04-30-mom_zone_crosshair.md
+++ b/_posts/convars/2020-04-30-mom_zone_crosshair.md
@@ -7,6 +7,7 @@ tags:
 minimum_value: 0
 maximum_value: 1
 default_value: 1
+requires_mapping: true
 ---
 
 Toggles the draw of the zoning crosshair/reticle.

--- a/_posts/convars/2020-04-30-mom_zone_debug.md
+++ b/_posts/convars/2020-04-30-mom_zone_debug.md
@@ -8,6 +8,7 @@ tags:
 minimum_value: 0
 maximum_value: 1
 default_value: 0
+requires_mapping: true
 ---
 
 Toggles debugging mode for zoning.

--- a/_posts/convars/2020-04-30-mom_zone_edit.md
+++ b/_posts/convars/2020-04-30-mom_zone_edit.md
@@ -7,6 +7,7 @@ tags:
 minimum_value: 0
 maximum_value: 1
 default_value: 0
+requires_mapping: true
 ---
 
 Toggles zone editing

--- a/_posts/convars/2020-04-30-mom_zone_grid.md
+++ b/_posts/convars/2020-04-30-mom_zone_grid.md
@@ -7,6 +7,7 @@ tags:
 minimum_value: 1
 maximum_value: 64
 default_value: 8
+requires_mapping: true
 ---
 
 The grid size used to create zones.

--- a/_posts/convars/2020-04-30-mom_zone_ignorewarning.md
+++ b/_posts/convars/2020-04-30-mom_zone_ignorewarning.md
@@ -7,6 +7,7 @@ tags:
 minimum_value: 0
 maximum_value: 1
 default_value: 0
+requires_mapping: true
 ---
 
 Toggles letting you create zones despite map already having both start and end zone.

--- a/_posts/convars/2020-04-30-mom_zone_start_limitspdmethod.md
+++ b/_posts/convars/2020-04-30-mom_zone_start_limitspdmethod.md
@@ -8,6 +8,7 @@ tags:
 minimum_value: 0
 maximum_value: 1
 default_value: 1
+requires_mapping: true
 ---
 
 Changes the limit speed method used in the start zone. Take into account player z-velocity = `0`, Ignore z-velocity = `1`.

--- a/_posts/convars/2020-04-30-mom_zone_start_maxleavespeed.md
+++ b/_posts/convars/2020-04-30-mom_zone_start_maxleavespeed.md
@@ -8,6 +8,7 @@ tags:
 minimum_value: 0
 maximum_value: 3500
 default_value: 350
+requires_mapping: true
 ---
 
 Max leave speed for the start trigger. `0` to disable.

--- a/_posts/convars/2020-04-30-mom_zone_track.md
+++ b/_posts/convars/2020-04-30-mom_zone_track.md
@@ -8,6 +8,7 @@ tags:
 minimum_value: 0
 maximum_value: 64
 default_value: 0
+requires_mapping: true
 ---
 
 What track to create the zone for. Main track = `0`, above `0` is a bonus track.

--- a/_posts/convars/2020-04-30-mom_zone_type.md
+++ b/_posts/convars/2020-04-30-mom_zone_type.md
@@ -11,6 +11,7 @@ tags:
 default_value: auto
 concommand_ref1: mom_zone_mark
 concommand_ref2: mom_zone_create
+requires_mapping: true
 ---
 
 Changes the type of zone to be created when using [`{{ page.concommand_ref1 }}`](/command/{{ page.concommand_ref1 }}) / [`{{ page.concommand_ref2 }}`](/command/{{ page.concommand_ref2 }}).

--- a/_posts/convars/2020-04-30-mom_zone_usenewmethod.md
+++ b/_posts/convars/2020-04-30-mom_zone_usenewmethod.md
@@ -7,6 +7,7 @@ tags:
 minimum_value: 0
 maximum_value: 1
 default_value: 0
+requires_mapping: true
 ---
 
 Toggles using new point-based zoning method by Mehis.

--- a/_posts/convars/2020-04-30-mom_zone_zonenum.md
+++ b/_posts/convars/2020-04-30-mom_zone_zonenum.md
@@ -7,6 +7,7 @@ tags:
 minimum_value: 0
 maximum_value: 64
 default_value: 0
+requires_mapping: true
 ---
 
 Sets the zone number. Use `0` to automatically determine one, otherwise start from `2`.


### PR DESCRIPTION
Child of PR #35 

Didn't see that there was a `requires_mapping` metadata field set up when I initially created the zoning vars/commands. This is documented (at the end of https://docs.momentum-mod.org/guide/create-docs-page/) I just missed it.

Went through all the cvars/ccommands that had the mapping flag in the game code just in case there were others. It's mostly just `sv_` and entity related cvar/ccommands though, not any momentum specific ones.