### PR TITLE
+ mom_run_safeguard_restart_stage & safeguard metadata

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -60,6 +60,15 @@ layout: default
           <h4 class="page__meta-title">{{ site.data.ui-text[site.locale].meta_label }}</h4>
         {% endif %}
 
+        {% comment %} For commands that have an associated safeguard {% endcomment %}
+        {% if page.safeguard %}
+          <p class="page__taxonomy">
+            <strong>This command has an associated run safeguard:</strong> 
+            <a href="/var/{{ page.safeguard }}"><code>{{ page.safeguard }}</code></a>
+          </p>
+          <br>
+        {% endif %}
+
         {% comment %} Show the min/max value of the convar if it exists {% endcomment %}
         {% if page.category == "var" %}
           {% if page.minimum_value or page.maximum_value or page.default_value %}

--- a/_posts/commands/2019-08-23-mom_restart.md
+++ b/_posts/commands/2019-08-23-mom_restart.md
@@ -6,6 +6,7 @@ tags:
   - teleport
 optional_params:
   - Track number
+safeguard: mom_run_safeguard_restart
 ---
 
 Restarts the player to the start trigger. Optionally takes a track number (default is main track).

--- a/_posts/commands/2020-05-01-mom_practice.md
+++ b/_posts/commands/2020-05-01-mom_practice.md
@@ -3,7 +3,7 @@ title: mom_practice
 category: command
 tags:
   - practice
-cvar_ref: mom_run_safeguard_practicemode
+safeguard: mom_run_safeguard_practicemode
 ---
 
 Toggles practice mode, allowing the player to fly around in noclip. 
@@ -13,7 +13,3 @@ Additionally, holding the jump key in this mode prevents the player from being t
 If toggled on during a run, 
 - the timer will continue to tick
 - when toggled off, the player will teleported back to the position where they first toggled it on
-
-### Note:
-
-This command has an associated safeguard [`{{ page.cvar_ref }}`](/var/{{ page.cvar_ref }}).

--- a/_posts/commands/2020-05-01-mom_saveloc_nav_first.md
+++ b/_posts/commands/2020-05-01-mom_saveloc_nav_first.md
@@ -3,6 +3,7 @@ title: mom_saveloc_nav_first
 category: command
 tags:
   - saveloc
+safeguard: mom_run_safeguard_saveloc_tele
 ---
 
 Goes to the first saveloc in the list and teleports the player to it.

--- a/_posts/commands/2020-05-01-mom_saveloc_nav_last.md
+++ b/_posts/commands/2020-05-01-mom_saveloc_nav_last.md
@@ -3,6 +3,7 @@ title: mom_saveloc_nav_last
 category: command
 tags:
   - saveloc
+safeguard: mom_run_safeguard_saveloc_tele
 ---
 
 Goes to the last saveloc in the list and teleports the player to it.

--- a/_posts/commands/2020-05-01-mom_saveloc_nav_next.md
+++ b/_posts/commands/2020-05-01-mom_saveloc_nav_next.md
@@ -3,6 +3,7 @@ title: mom_saveloc_nav_next
 category: command
 tags:
   - saveloc
+safeguard: mom_run_safeguard_saveloc_tele
 ---
 
 Goes forwards through the saveloc list, while teleporting the player to each.

--- a/_posts/commands/2020-05-01-mom_saveloc_nav_prev.md
+++ b/_posts/commands/2020-05-01-mom_saveloc_nav_prev.md
@@ -3,6 +3,7 @@ title: mom_saveloc_nav_prev
 category: command
 tags:
   - saveloc
+safeguard: mom_run_safeguard_saveloc_tele
 ---
 
 Goes backwards through the saveloc list, while teleporting the player to each.

--- a/_posts/commands/2020-07-10-mom_restart_stage.md
+++ b/_posts/commands/2020-07-10-mom_restart_stage.md
@@ -8,6 +8,7 @@ optional_params:
   - Stage number
   - Track number
 ccom_ref: mom_restart
+safeguard: mom_run_safeguard_restart_stage
 ---
 
 Teleports the player to the start of the current stage on the current track. 

--- a/_posts/convars/2020-07-11-mom_run_safeguard_restart_stage.md
+++ b/_posts/convars/2020-07-11-mom_run_safeguard_restart_stage.md
@@ -1,0 +1,13 @@
+---
+title: mom_run_safeguard_restart_stage
+category: var
+tags:
+  - safeguard
+minimum_value: 0
+maximum_value: 2
+default_value: 1
+---
+
+Changes the safeguard for teleporting to a stage during a run. 
+
+Off = `0`, Restart only when not pressing any movement keys = `1`, Restart only on double press =`2`.


### PR DESCRIPTION
Closes #53 

Added `mom_run_safeguard_restart_stage`:
![image](https://user-images.githubusercontent.com/9014762/87231752-b80e8680-c36e-11ea-9c5c-34cee0e7a3ba.png)

Also added a metadata field for commands that are safeguarded, which adds a little blurb and links to the safeguard:
![image](https://user-images.githubusercontent.com/9014762/87231779-e9875200-c36e-11ea-835a-d82748dcf368.png)
