### PR TITLE
Fix GitHub and Twitter style

### DIFF
--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -83,7 +83,7 @@ $dribbble-color: #ea4c89 !default;
 $facebook-color: #3b5998 !default;
 $flickr-color: #ff0084 !default;
 $foursquare-color: #0072b1 !default;
-$github-color: #171516 !default;
+$github-color: #fff !default;
 $gitlab-color: #e24329 !default;
 $instagram-color: #517fa4 !default;
 $lastfm-color: #d51007 !default;

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -95,7 +95,7 @@ $rss-color: #fa9b39 !default;
 $soundcloud-color: #ff3300 !default;
 $stackoverflow-color: #fe7a15 !default;
 $tumblr-color: #32506d !default;
-$twitter-color: #55acee !default;
+$twitter-color: #fff !default;
 $vimeo-color: #1ab7ea !default;
 $vine-color: #00bf8f !default;
 $youtube-color: #bb0000 !default;


### PR DESCRIPTION
### Issue
The minimal mistakes scss was changing the default text color for the discord and twitter icons through _variables.scss which caused for github's logo to blend in with the dark footer. This pull request sets these variables to white to match with the discord icon style.

### Screenshots

Current live site:
![image](https://user-images.githubusercontent.com/49064563/87237143-f173e000-c3c8-11ea-894c-3b38ac99fc4c.png)

Proposed changes:
![image](https://user-images.githubusercontent.com/49064563/87237151-0cdeeb00-c3c9-11ea-9079-9fc27caaff11.png)

