### PR TITLE
Update mom_saveloc_create to include & refer to start mark creation

### DIFF
--- a/_posts/commands/2020-05-01-mom_saveloc_create.md
+++ b/_posts/commands/2020-05-01-mom_saveloc_create.md
@@ -3,6 +3,8 @@ title: mom_saveloc_create
 category: command
 tags:
   - saveloc
+ccom_ref: mom_start_mark_create
 ---
 
-Creates a saveloc which saves the player's state.
+Creates a saveloc which saves the player's state. 
+When called in a start zone, creates a start mark instead (see [`{{ page.ccom_ref }}`](/command/{{ page.ccom_ref }})).

--- a/_posts/commands/2020-05-01-mom_start_mark_clear.md
+++ b/_posts/commands/2020-05-01-mom_start_mark_clear.md
@@ -4,8 +4,19 @@ category: command
 tags:
   - start
   - mark
+optional_params:
+  - Track number
 ---
 
-Clears the saved start location for the current track if there is one. 
+Clears the current track's saved start location if there is one. 
+Optionally accepts a track number.
 
-Also accepts a track number. Eg. `mom_start_mark_clear 2` clears track 2's start mark.
+## Usage Example
+
+> `mom_start_mark_clear`
+
+Clears the start mark on the current track.
+
+> `mom_start_mark_clear 2`
+
+Clears the start mark on track 2.

--- a/_posts/commands/2020-05-01-mom_start_mark_create.md
+++ b/_posts/commands/2020-05-01-mom_start_mark_create.md
@@ -6,4 +6,5 @@ tags:
   - mark
 ---
 
-Marks a starting point inside the start zone trigger for a customized starting location/angle.
+Creates a starting mark (a customized starting location/angle) for the current track.
+Only operates when inside a start zone trigger.


### PR DESCRIPTION
Closes #68 

Updated description of `mom_saveloc_create` to include the fact that a start mark is created with the command if used inside of a start zone.

Also I found that the start mark commands needed some updating; felt that the fact that you can have a start mark per track was not captured in these descriptions. Reworded them to do so.
Also `mom_start_mark_clear` did not have `optional_params` metadata nor a usage example. Added that.