### PR TITLE
Add toggle_* commands

### DIFF
--- a/_posts/commands/2020-09-20-toggle_duck.md
+++ b/_posts/commands/2020-09-20-toggle_duck.md
@@ -1,0 +1,11 @@
+---
+title: toggle_duck
+category: command
+tags:
+  - movement
+  - player
+ccom_ref1: mom_restart
+ccom_ref2: mom_restart_stage
+---
+
+Toggles duck input. Toggle resets when restarting a map or stage via [`{{ page.ccom_ref1 }}`](/command/{{ page.ccom_ref1 }}) or [`{{ page.ccom_ref2 }}`](/command/{{ page.ccom_ref2 }}) respectively.

--- a/_posts/commands/2020-09-20-toggle_jump.md
+++ b/_posts/commands/2020-09-20-toggle_jump.md
@@ -1,0 +1,16 @@
+---
+title: toggle_jump
+category: command
+tags:
+  - movement
+  - player
+  - surf
+  - bhop
+  - ahop
+  - parkour
+  - tricksurf
+ccom_ref1: mom_restart
+ccom_ref2: mom_restart_stage
+---
+
+Toggles jump input for gamemodes with autohop. Toggle resets when restarting a map or stage via [`{{ page.ccom_ref1 }}`](/command/{{ page.ccom_ref1 }}) or [`{{ page.ccom_ref2 }}`](/command/{{ page.ccom_ref2 }}) respectively.

--- a/_posts/commands/2020-09-20-toggle_speed.md
+++ b/_posts/commands/2020-09-20-toggle_speed.md
@@ -1,0 +1,13 @@
+---
+title: toggle_speed
+category: command
+tags:
+  - movement
+  - player
+  - ahop
+  - parkour
+ccom_ref1: mom_restart
+ccom_ref2: mom_restart_stage
+---
+
+Toggles sprint input for gamemodes with the ability to `+speed`. Toggle resets when restarting a map or stage via [`{{ page.ccom_ref1 }}`](/command/{{ page.ccom_ref1 }}) or [`{{ page.ccom_ref2 }}`](/command/{{ page.ccom_ref2 }}) respectively, and when the player cannot sprint (eg. crouching).

--- a/_posts/commands/2020-09-20-toggle_walk.md
+++ b/_posts/commands/2020-09-20-toggle_walk.md
@@ -1,0 +1,12 @@
+---
+title: toggle_walk
+category: command
+tags:
+  - movement
+  - player
+  - ahop
+ccom_ref1: mom_restart
+ccom_ref2: mom_restart_stage
+---
+
+Toggles walk input for gamemodes with the ability to `+walk`. Toggle resets when restarting a map or stage via [`{{ page.ccom_ref1 }}`](/command/{{ page.ccom_ref1 }}) or [`{{ page.ccom_ref2 }}`](/command/{{ page.ccom_ref2 }}) respectively, and when the player cannot walk (eg. crouching).

--- a/_posts/convars/2020-05-17-mom_ahop_sound_sprint_enable.md
+++ b/_posts/convars/2020-05-17-mom_ahop_sound_sprint_enable.md
@@ -2,9 +2,9 @@
 title: mom_ahop_sound_sprint_enable
 category: var
 tags:
-  - sprint
   - player
   - ahop
+  - sound
 minimum_value: 0
 maximum_value: 1
 default_value: 1


### PR DESCRIPTION
Closes #77

Adds
- `toggle_duck`
- `toggle_jump`
- `toggle_walk`
- `toggle_speed`

Removed the sprint tag as it feels redundant given there is one cvar under it and ahop/parkour tags exist.
Added missing `sound` tag to `mom_ahop_sound_sprint_enable`.
