### PR TITLE
Viewmodel offset cvars

### DIFF
--- a/_posts/convars/2020-04-30-r_viewmodel_opacity.md
+++ b/_posts/convars/2020-04-30-r_viewmodel_opacity.md
@@ -6,6 +6,7 @@ tags:
   - alpha
 minimum_value: 0.01
 maximum_value: 1
+default_value: 1
 ---
 
 Controls the opacity of viewmodels.

--- a/_posts/convars/2020-09-20-viewmodel_offset_x.md
+++ b/_posts/convars/2020-09-20-viewmodel_offset_x.md
@@ -1,0 +1,11 @@
+---
+title: viewmodel_offset_x
+category: var
+tags:
+  - viewmodel
+default_value: 0
+ccom_ref1: viewmodel_offset_y
+ccom_ref2: viewmodel_offset_z
+---
+
+Controls the offset of the viewmodel in the X coordinate. For other coordinates see [`{{ page.ccom_ref1 }}`](/var/{{ page.ccom_ref1 }}) and [`{{ page.ccom_ref2 }}`](/var/{{ page.ccom_ref2 }}).

--- a/_posts/convars/2020-09-20-viewmodel_offset_y.md
+++ b/_posts/convars/2020-09-20-viewmodel_offset_y.md
@@ -1,0 +1,11 @@
+---
+title: viewmodel_offset_y
+category: var
+tags:
+  - viewmodel
+default_value: 0
+ccom_ref1: viewmodel_offset_x
+ccom_ref2: viewmodel_offset_z
+---
+
+Controls the offset of the viewmodel in the Y coordinate. For other coordinates see [`{{ page.ccom_ref1 }}`](/var/{{ page.ccom_ref1 }}) and [`{{ page.ccom_ref2 }}`](/var/{{ page.ccom_ref2 }}).

--- a/_posts/convars/2020-09-20-viewmodel_offset_z.md
+++ b/_posts/convars/2020-09-20-viewmodel_offset_z.md
@@ -1,0 +1,11 @@
+---
+title: viewmodel_offset_z
+category: var
+tags:
+  - viewmodel
+default_value: 0
+ccom_ref1: viewmodel_offset_x
+ccom_ref2: viewmodel_offset_y
+---
+
+Controls the offset of the viewmodel in the Z coordinate. For other coordinates see [`{{ page.ccom_ref1 }}`](/var/{{ page.ccom_ref1 }}) and [`{{ page.ccom_ref2 }}`](/var/{{ page.ccom_ref2 }}).


### PR DESCRIPTION
Closes #73 

Adds cvars:

- `viewmodel_offset_x`
- `viewmodel_offset_y`
- `viewmodel_offset_z`

Also adds missing default value metadata to `r_viewmodel_opacity`.

![image](https://user-images.githubusercontent.com/9014762/93739205-961a5700-fb9c-11ea-8d93-bd787843f0d5.png)
