### PR TITLE
Add main menu drawer cvars and chat command/cvars

### DIFF
--- a/_posts/commands/2020-09-21-chat_open.md
+++ b/_posts/commands/2020-09-21-chat_open.md
@@ -1,0 +1,9 @@
+---
+title: chat_open
+category: command
+tags:
+  - hud
+  - chat
+---
+
+Opens the in-game chat window.

--- a/_posts/convars/2020-09-21-mom_chat_sound_enable.md
+++ b/_posts/convars/2020-09-21-mom_chat_sound_enable.md
@@ -1,0 +1,12 @@
+---
+title: mom_chat_sound_enable
+category: var
+tags:
+  - chat
+  - sound
+minimum_value: 0
+maximum_value: 1
+default_value: 1
+---
+
+Toggles playing a sound on sending or recieving a chat message.

--- a/_posts/convars/2020-09-21-mom_chat_spectate_tag.md
+++ b/_posts/convars/2020-09-21-mom_chat_spectate_tag.md
@@ -1,0 +1,10 @@
+---
+title: mom_chat_spectate_tag
+category: var
+tags:
+  - chat
+  - spectate
+default_value: ​*SPEC*
+---
+
+Changes the spectate tag used in chat to denote spectating players.

--- a/_posts/convars/2020-09-21-mom_chat_typing_status_enable.md
+++ b/_posts/convars/2020-09-21-mom_chat_typing_status_enable.md
@@ -1,0 +1,11 @@
+---
+title: mom_chat_typing_status_enable
+category: var
+tags:
+  - chat
+minimum_value: 0
+maximum_value: 1
+default_value: 1
+---
+
+Toggles showing your typing status in the lobby.

--- a/_posts/convars/2020-09-21-mom_drawer_animation_enable.md
+++ b/_posts/convars/2020-09-21-mom_drawer_animation_enable.md
@@ -1,0 +1,11 @@
+---
+title: mom_drawer_animation_enable
+category: var
+tags:
+  - menu drawer
+minimum_value: 0
+maximum_value: 1
+default_value: 1
+---
+
+Toggle the opening/closing animation of the main menu drawer panel.

--- a/_posts/convars/2020-09-21-mom_drawer_animation_time.md
+++ b/_posts/convars/2020-09-21-mom_drawer_animation_time.md
@@ -1,0 +1,11 @@
+---
+title: mom_drawer_animation_time
+category: var
+tags:
+  - menu drawer
+minimum_value: 0.01
+maximum_value: 500
+default_value: 0.33
+---
+
+Controls the amount of time the main menu drawer opening/closing animation lasts, in seconds.


### PR DESCRIPTION
Closes #74 

Adds:
- `mom_drawer_animation_enable`
- `mom_drawer_animation_time`
- `mom_chat_typing_status_enable`
- `mom_chat_spectate_tag`
- `mom_chat_sound_enable`
- `chat_open`

Don't mind the zero-width space in the `default_value` metadata for `mom_chat_spectate_tag`. YML doesn't parse metadata fields that start with an asterisk..

![image](https://user-images.githubusercontent.com/9014762/93743567-1ba20500-fba5-11ea-8225-e46e2cb681b2.png)

![image](https://user-images.githubusercontent.com/9014762/93743290-a6363480-fba4-11ea-9fd6-00139ccbeb09.png)
