### PR TITLE
Give pages without toc full width

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -17,7 +17,7 @@ layout: default
 <div id="main" role="main">
   {% include sidebar.html %}
 
-  <article class="page" itemscope itemtype="https://schema.org/CreativeWork">
+  <article class="page{% if page.toc %} toc_pad{% endif %}" itemscope itemtype="https://schema.org/CreativeWork">
     {% if page.title %}<meta itemprop="headline" content="{{ page.title | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date: "%B %d, %Y" }}">{% endif %}

--- a/_sass/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/_page.scss
@@ -30,16 +30,25 @@ body {
   flex: 1 0 auto;
 }
 
-.page {
+.toc_pad
+{
   @include breakpoint($large) {
-    float: right;
-    width: calc(100% - #{$right-sidebar-width-narrow});
     padding-right: $right-sidebar-width-narrow;
   }
 
   @include breakpoint($x-large) {
-    width: calc(100% - #{$right-sidebar-width});
     padding-right: $right-sidebar-width;
+  }
+}
+
+.page {
+  @include breakpoint($large) {
+    float: right;
+    width: calc(100% - #{$right-sidebar-width-narrow});
+  }
+
+  @include breakpoint($x-large) {
+    width: calc(100% - #{$right-sidebar-width});
   }
 
   .page__inner-wrap {


### PR DESCRIPTION
Very annoying how pages without a table of contents still have right padding as if they did. 
This change allows pages without a table of contents to have their full width.

With table of contents (normal):
![image](https://user-images.githubusercontent.com/9014762/93747979-5d827980-fbac-11ea-8a78-a6e617051479.png)

Without table of contents, before this change:
![image](https://user-images.githubusercontent.com/9014762/93748256-c8cc4b80-fbac-11ea-9b7d-44b19d3e566c.png)

Without table of contents, after this change:
![image](https://user-images.githubusercontent.com/9014762/93748194-b4884e80-fbac-11ea-836d-913749212a3b.png)
