### PR TITLE
Give landing, category, and tag pages full width

### DIFF
--- a/_sass/minimal-mistakes/_archive.scss
+++ b/_sass/minimal-mistakes/_archive.scss
@@ -9,12 +9,10 @@
   @include breakpoint($large) {
     float: right;
     width: calc(100% - #{$right-sidebar-width-narrow});
-    padding-right: $right-sidebar-width-narrow;
   }
 
   @include breakpoint($x-large) {
     width: calc(100% - #{$right-sidebar-width});
-    padding-right: $right-sidebar-width;
   }
 }
 


### PR DESCRIPTION
Same as https://github.com/momentum-mod/docs/pull/87 but for the landing, categories, and tags pages.

These don't use table of contents anyhow so padding can be removed entirely.

![image](https://user-images.githubusercontent.com/9014762/94378248-e03f9300-00dc-11eb-8a10-bf08430953ed.png)

vs.

![image](https://user-images.githubusercontent.com/9014762/94378255-f1889f80-00dc-11eb-9007-8ba06d059fea.png)
