### PR TITLE
Correct Zone path in "Basic Zoning" guide

### DIFF
--- a/_posts/guides/2019-08-27-guide_basic_zoning.md
+++ b/_posts/guides/2019-08-27-guide_basic_zoning.md
@@ -90,7 +90,7 @@ To create the End Zone, go to where you want it and repeat the process, you shou
 If all goes well you should be able to click ***Save Zones***, close the GUI and test the map.  
 
 Zones are stored in a `.zon` file of the same name as the map.  
-So for this example the map is called *"cubemaptest"* so the `maps/` folder will now have a `cubemaptest.zon` file.
+So for this example the map is called *"cubemaptest"* so the `zones/` folder will now have a `cubemaptest.zon` file.
 
 > This should be enough for basic testing and Linear maps.  
 > For more than one Stage or Bonuses check the [Advanced Zoning](/guide/advanced-zoning/) Guide.


### PR DESCRIPTION
Zones were moved to their own folder instead of the `maps/` one, so this guide was incorrect.
See: https://github.com/momentum-mod/game/pull/538

Closes #99 