### PR TITLE
Add menu-related safeguards & add missing safeguard metadata

### DIFF
--- a/_posts/commands/2020-05-01-mom_saveloc_current.md
+++ b/_posts/commands/2020-05-01-mom_saveloc_current.md
@@ -3,6 +3,7 @@ title: mom_saveloc_current
 category: command
 tags:
   - saveloc
+safeguard: mom_run_safeguard_saveloc_tele
 ---
 
 Teleports the player to their current saved location.

--- a/_posts/commands/2020-09-21-chat_open.md
+++ b/_posts/commands/2020-09-21-chat_open.md
@@ -4,6 +4,7 @@ category: command
 tags:
   - hud
   - chat
+safeguard: mom_run_safeguard_chat_open
 ---
 
 Opens the in-game chat window.

--- a/_posts/convars/2020-10-05-mom_run_safeguard_change_map.md
+++ b/_posts/convars/2020-10-05-mom_run_safeguard_change_map.md
@@ -1,0 +1,14 @@
+---
+title: mom_run_safeguard_change_map
+category: var
+tags:
+  - safeguard
+  - map
+minimum_value: 0
+maximum_value: 1
+default_value: 1
+---
+
+Toggles the safeguard for changing map during a run.
+
+Confirmation will be requested via a popup if set to 1 (on) and the timer is running.

--- a/_posts/convars/2020-10-05-mom_run_safeguard_quit_game.md
+++ b/_posts/convars/2020-10-05-mom_run_safeguard_quit_game.md
@@ -1,0 +1,13 @@
+---
+title: mom_run_safeguard_quit_game
+category: var
+tags:
+  - safeguard
+minimum_value: 0
+maximum_value: 1
+default_value: 1
+---
+
+Toggles the safeguard for quitting the game during a run.
+
+Confirmation will be requested via a popup if set to 1 (on) and the timer is running.

--- a/_posts/convars/2020-10-05-mom_run_safeguard_quit_map.md
+++ b/_posts/convars/2020-10-05-mom_run_safeguard_quit_map.md
@@ -1,0 +1,13 @@
+---
+title: mom_run_safeguard_quit_map
+category: var
+tags:
+  - safeguard
+minimum_value: 0
+maximum_value: 1
+default_value: 1
+---
+
+Toggles the safeguard for quitting to the main menu during a run.
+
+Confirmation will be requested via a popup if set to 1 (on) and the timer is running.


### PR DESCRIPTION
Closes #97 

Adds:
- `mom_run_safeguard_change_map`
- `mom_run_safeguard_quit_map`
- `mom_run_safeguard_quit_game`

Updates:
- `mom_saveloc_current`
- `chat_open`

to reference the associated safeguard.

![image](https://user-images.githubusercontent.com/9014762/95159158-30100100-0752-11eb-844a-d77d7682917d.png)
