### PR TITLE
Update site font size

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > A documentation website for Momentum Mod, running on [Jekyll](https://jekyllrb.com/) and using the [Minimal Mistakes](https://github.com/mmistakes/minimal-mistakes) theme.
 
+All documentation is kept up with the game's development branch not our current release version on Steam.
+
 ## What This Is
 
 This repo is an open source collection of documentation for various aspects of the game Momentum Mod. This includes (but is not exactly limited to):

--- a/_sass/minimal-mistakes/_navigation.scss
+++ b/_sass/minimal-mistakes/_navigation.scss
@@ -498,7 +498,7 @@
 
   .toc__title {
     margin: 0;
-    padding: 0.5rem 0.75rem;
+    padding: 0.5rem 0 0.35rem 0.75rem;
     font-family: $serif;
     font-size: $type-size-5;
     font-weight: normal;

--- a/_sass/minimal-mistakes/_reset.scss
+++ b/_sass/minimal-mistakes/_reset.scss
@@ -8,18 +8,18 @@ html {
   /* apply a natural box layout model to all elements */
   box-sizing: border-box;
   background-color: $background-color;
-  font-size: 16px;
+  font-size: 14px;
 
   @include breakpoint($medium) {
-    font-size: 18px;
+    font-size: 16px;
   }
 
   @include breakpoint($large) {
-    font-size: 20px;
+    font-size: 18px;
   }
 
   @include breakpoint($x-large) {
-    font-size: 22px;
+    font-size: 20px;
   }
 
   -webkit-text-size-adjust: 100%;


### PR DESCRIPTION
Lowers the site's font size as the text is quite big with the new fonts. Has the added benefit of not truncating anything on the sidebar (at least in full 1080p).

Also adds a short blurb explaining that this site is kept up to date with our development branch rather than the steam release.

Old:
![image](https://user-images.githubusercontent.com/9014762/96179866-66821480-0ee6-11eb-84b1-330ee9eedac5.png)

New:
![image](https://user-images.githubusercontent.com/9014762/96179905-7699f400-0ee6-11eb-9f35-f41a6df78160.png)
