### PR TITLE
Remove jquery references in autoscroll script

### DIFF
--- a/assets/js/autoscroll.js
+++ b/assets/js/autoscroll.js
@@ -1,6 +1,6 @@
-const scrollElem = SimpleBar.instances.get($('.sidebar')[0]).getScrollElement();
+const scrollElem = SimpleBar.instances.get(document.getElementsByClassName('sidebar')[0]).getScrollElement();
 scrollElem.scrollBy({
-  top: $('#sidebar-anchor').position().top - Math.max(scrollElem.clientHeight) / 2 + $('.masthead')[0].clientHeight,
+  top: document.getElementById('sidebar-anchor').offsetTop - Math.max(scrollElem.clientHeight) / 2 + document.getElementsByClassName('masthead')[0].clientHeight,
   left: 0,
   behavior: 'smooth'
 });


### PR DESCRIPTION
Local serve includes jquery but the site does not, which caused the autoscroll functionality to break. 