### PR TITLE
Update docs with fail tele

### DIFF
--- a/_posts/commands/2020-09-20-toggle_duck.md
+++ b/_posts/commands/2020-09-20-toggle_duck.md
@@ -6,6 +6,10 @@ tags:
   - player
 ccom_ref1: mom_restart
 ccom_ref2: mom_restart_stage
+ent_ref1: trigger_momentum_teleport
+ent_ref2: trigger_momentum_teleport_progress
+ent_ref3: trigger_momentum_multihop
+ent_ref4: trigger_momentum_onehop
 ---
 
-Toggles duck input. Toggle resets when restarting a map or stage via [`{{ page.ccom_ref1 }}`](/command/{{ page.ccom_ref1 }}) or [`{{ page.ccom_ref2 }}`](/command/{{ page.ccom_ref2 }}) respectively.
+Toggles duck input. Toggle resets when hitting a fail teleport (see [`{{ page.ent_ref1 }}`](/entity/{{ page.ent_ref1 }}), [`{{ page.ent_ref2 }}`](/entity/{{ page.ent_ref2 }}), [`{{ page.ent_ref3 }}`](/entity/{{ page.ent_ref3 }}), and [`{{ page.ent_ref4 }}`](/entity/{{ page.ent_ref4 }})), and when restarting a map or stage via [`{{ page.ccom_ref1 }}`](/command/{{ page.ccom_ref1 }}) or [`{{ page.ccom_ref2 }}`](/command/{{ page.ccom_ref2 }}) respectively.

--- a/_posts/commands/2020-09-20-toggle_jump.md
+++ b/_posts/commands/2020-09-20-toggle_jump.md
@@ -11,6 +11,10 @@ tags:
   - tricksurf
 ccom_ref1: mom_restart
 ccom_ref2: mom_restart_stage
+ent_ref1: trigger_momentum_teleport
+ent_ref2: trigger_momentum_teleport_progress
+ent_ref3: trigger_momentum_multihop
+ent_ref4: trigger_momentum_onehop
 ---
 
-Toggles jump input for gamemodes with autohop. Toggle resets when restarting a map or stage via [`{{ page.ccom_ref1 }}`](/command/{{ page.ccom_ref1 }}) or [`{{ page.ccom_ref2 }}`](/command/{{ page.ccom_ref2 }}) respectively.
+Toggles jump input for gamemodes with autohop. Toggle resets when hitting a fail teleport (see [`{{ page.ent_ref1 }}`](/entity/{{ page.ent_ref1 }}), [`{{ page.ent_ref2 }}`](/entity/{{ page.ent_ref2 }}), [`{{ page.ent_ref3 }}`](/entity/{{ page.ent_ref3 }}), and [`{{ page.ent_ref4 }}`](/entity/{{ page.ent_ref4 }})), and when restarting a map or stage via [`{{ page.ccom_ref1 }}`](/command/{{ page.ccom_ref1 }}) or [`{{ page.ccom_ref2 }}`](/command/{{ page.ccom_ref2 }}) respectively.

--- a/_posts/commands/2020-09-20-toggle_speed.md
+++ b/_posts/commands/2020-09-20-toggle_speed.md
@@ -8,6 +8,10 @@ tags:
   - parkour
 ccom_ref1: mom_restart
 ccom_ref2: mom_restart_stage
+ent_ref1: trigger_momentum_teleport
+ent_ref2: trigger_momentum_teleport_progress
+ent_ref3: trigger_momentum_multihop
+ent_ref4: trigger_momentum_onehop
 ---
 
-Toggles sprint input for gamemodes with the ability to `+speed`. Toggle resets when restarting a map or stage via [`{{ page.ccom_ref1 }}`](/command/{{ page.ccom_ref1 }}) or [`{{ page.ccom_ref2 }}`](/command/{{ page.ccom_ref2 }}) respectively, and when the player cannot sprint (eg. crouching).
+Toggles sprint input for gamemodes with the ability to `+speed`. Toggle resets when the player cannot sprint (eg. crouching), when hitting a fail teleport (see [`{{ page.ent_ref1 }}`](/entity/{{ page.ent_ref1 }}), [`{{ page.ent_ref2 }}`](/entity/{{ page.ent_ref2 }}), [`{{ page.ent_ref3 }}`](/entity/{{ page.ent_ref3 }}), and [`{{ page.ent_ref4 }}`](/entity/{{ page.ent_ref4 }})), and when restarting a map or stage via [`{{ page.ccom_ref1 }}`](/command/{{ page.ccom_ref1 }}) or [`{{ page.ccom_ref2 }}`](/command/{{ page.ccom_ref2 }}) respectively.

--- a/_posts/commands/2020-09-20-toggle_walk.md
+++ b/_posts/commands/2020-09-20-toggle_walk.md
@@ -7,6 +7,10 @@ tags:
   - ahop
 ccom_ref1: mom_restart
 ccom_ref2: mom_restart_stage
+ent_ref1: trigger_momentum_teleport
+ent_ref2: trigger_momentum_teleport_progress
+ent_ref3: trigger_momentum_multihop
+ent_ref4: trigger_momentum_onehop
 ---
 
-Toggles walk input for gamemodes with the ability to `+walk`. Toggle resets when restarting a map or stage via [`{{ page.ccom_ref1 }}`](/command/{{ page.ccom_ref1 }}) or [`{{ page.ccom_ref2 }}`](/command/{{ page.ccom_ref2 }}) respectively, and when the player cannot walk (eg. crouching).
+Toggles walk input for gamemodes with the ability to `+walk`. Toggle resets when the player cannot walk (eg. crouching), when hitting a fail teleport (see [`{{ page.ent_ref1 }}`](/entity/{{ page.ent_ref1 }}), [`{{ page.ent_ref2 }}`](/entity/{{ page.ent_ref2 }}), [`{{ page.ent_ref3 }}`](/entity/{{ page.ent_ref3 }}), and [`{{ page.ent_ref4 }}`](/entity/{{ page.ent_ref4 }})), and when restarting a map or stage via [`{{ page.ccom_ref1 }}`](/command/{{ page.ccom_ref1 }}) or [`{{ page.ccom_ref2 }}`](/command/{{ page.ccom_ref2 }}) respectively.

--- a/_posts/entities/2019-09-08-trigger_momentum_teleport.md
+++ b/_posts/entities/2019-09-08-trigger_momentum_teleport.md
@@ -41,6 +41,12 @@ Resets the velocity of the player after being teleported to the Remote Destinati
 
 Resets the view angles of the player after being teleported to the Remote Destination. Default is true.
 
+>**Fail Teleport** (fail&lt;**choices**&gt;)
+ - **0**: False
+ - **1**: True
+
+Indicates whether this teleport is for failing a level. Default is false.
+
 ## Flags
 
 >**Teleport the player on EndTouch() instead of StartTouch() (8388608)**  

--- a/_posts/entities/2019-09-08-trigger_momentum_teleport.md
+++ b/_posts/entities/2019-09-08-trigger_momentum_teleport.md
@@ -17,19 +17,29 @@ A [trigger](https://developer.valvesoftware.com/wiki/Triggers){:target="blank"} 
 
 >**Track Number** (track_number&lt;**integer**&gt;)
 
-The track that this zone belongs to: 
+The track that this teleport belongs to: 
 
  - **-1**: All Tracks
  - **0**: Main Map
  - **1+**: Bonus Tracks
 
->**Stop player on teleport** (stop&lt;**boolean**&gt;)
+Default is -1.
 
- Resets the velocity of the player after being teleported to the Remote Destination.
+>**Remote Destination** (target&lt;**target_destination**&gt;)  
 
->**Reset the player angles on teleport** (resetang&lt;**boolean**&gt;)
+The entity specifying the point to which the player should be teleported.
 
- Resets the view angles of the player after being teleported to the Remote Destination.
+>**Stop player on teleport** (stop&lt;**choices**&gt;)
+ - **0**: False
+ - **1**: True
+
+Resets the velocity of the player after being teleported to the Remote Destination. Default is true.
+
+>**Reset the player angles on teleport** (resetang&lt;**choices**&gt;)
+ - **0**: False
+ - **1**: True
+
+Resets the view angles of the player after being teleported to the Remote Destination. Default is true.
 
 ## Flags
 

--- a/_posts/entities/2020-07-15-trigger_momentum_teleport_progress.md
+++ b/_posts/entities/2020-07-15-trigger_momentum_teleport_progress.md
@@ -38,3 +38,9 @@ Resets the velocity of the player after being teleported to the Remote Destinati
  - **1**: True
 
 Resets the view angles of the player after being teleported to the Remote Destination. Default is true.
+
+>**Fail Teleport** (fail&lt;**choices**&gt;)
+ - **0**: False
+ - **1**: True
+
+Indicates whether this teleport is for failing a level. Default is false.

--- a/_posts/entities/2020-07-15-trigger_momentum_teleport_progress.md
+++ b/_posts/entities/2020-07-15-trigger_momentum_teleport_progress.md
@@ -15,24 +15,26 @@ Trigger that teleports the player to their last touched trigger_momentum_progres
 
 >**Track Number** (track_number&lt;**integer**&gt;)
 
-The track that this trigger belongs to: 
+The track that this teleport belongs to: 
 
  - **-1**: All Tracks
  - **0**: Main Map
  - **1+**: Bonus Tracks
 
+Default is -1.
+
 >**Remote Destination** (target&lt;**target_destination**&gt;)  
 
 The entity specifying the point to which the player should be teleported.
 
->**Stop player on teleport** (stop&lt;**choices**&gt;)  
+>**Stop player on teleport** (stop&lt;**choices**&gt;)
  - **0**: False
  - **1**: True
 
-The default value is 1.
+Resets the velocity of the player after being teleported to the Remote Destination. Default is true.
 
 >**Reset the player angles on teleport** (resetang&lt;**choices**&gt;)
  - **0**: False
  - **1**: True
 
-The default value is 1.
+Resets the view angles of the player after being teleported to the Remote Destination. Default is true.

--- a/_posts/entities/2020-07-16-trigger_momentum_multihop.md
+++ b/_posts/entities/2020-07-16-trigger_momentum_multihop.md
@@ -14,27 +14,29 @@ Trigger that allows for multiple hops inside of it, and teleports the player if 
 
 >**Track Number** (track_number&lt;**integer**&gt;)
 
-The track that this trigger belongs to: 
+The track that this teleport belongs to: 
 
  - **-1**: All Tracks
  - **0**: Main Map
  - **1+**: Bonus Tracks
 
+Default is -1.
+
 >**Remote Destination** (target&lt;**target_destination**&gt;)  
 
 The entity specifying the point to which the player should be teleported.
 
->**Stop player on teleport** (stop&lt;**choices**&gt;)  
+>**Stop player on teleport** (stop&lt;**choices**&gt;)
  - **0**: False
  - **1**: True
 
-The default value is 1.
+Resets the velocity of the player after being teleported to the Remote Destination. Default is true.
 
 >**Reset the player angles on teleport** (resetang&lt;**choices**&gt;)
  - **0**: False
  - **1**: True
 
-The default value is 1.
+Resets the view angles of the player after being teleported to the Remote Destination. Default is true.
 
 >**Hold Time (seconds)** (hold&lt;**float**&gt;)
 

--- a/_posts/entities/2020-07-16-trigger_momentum_multihop.md
+++ b/_posts/entities/2020-07-16-trigger_momentum_multihop.md
@@ -38,6 +38,12 @@ Resets the velocity of the player after being teleported to the Remote Destinati
 
 Resets the view angles of the player after being teleported to the Remote Destination. Default is true.
 
+>**Fail Teleport** (fail&lt;**choices**&gt;)
+ - **0**: False
+ - **1**: True
+
+Indicates whether this teleport is for failing a level. Default is false.
+
 >**Hold Time (seconds)** (hold&lt;**float**&gt;)
 
 If the player is in this trigger for longer than this (in seconds), teleport them to the most recent progress trigger.

--- a/_posts/entities/2020-07-16-trigger_momentum_onehop.md
+++ b/_posts/entities/2020-07-16-trigger_momentum_onehop.md
@@ -16,27 +16,29 @@ Trigger that teleports the player after only one entry, or if they stay inside f
 
 >**Track Number** (track_number&lt;**integer**&gt;)
 
-The track that this trigger belongs to: 
+The track that this teleport belongs to: 
 
  - **-1**: All Tracks
  - **0**: Main Map
  - **1+**: Bonus Tracks
 
+Default is -1.
+
 >**Remote Destination** (target&lt;**target_destination**&gt;)  
 
 The entity specifying the point to which the player should be teleported.
 
->**Stop player on teleport** (stop&lt;**choices**&gt;)  
+>**Stop player on teleport** (stop&lt;**choices**&gt;)
  - **0**: False
  - **1**: True
 
-The default value is 1.
+Resets the velocity of the player after being teleported to the Remote Destination. Default is true.
 
 >**Reset the player angles on teleport** (resetang&lt;**choices**&gt;)
  - **0**: False
  - **1**: True
 
-The default value is 1.
+Resets the view angles of the player after being teleported to the Remote Destination. Default is true.
 
 >**Hold Time (seconds)** (hold&lt;**float**&gt;)
 

--- a/_posts/entities/2020-07-16-trigger_momentum_onehop.md
+++ b/_posts/entities/2020-07-16-trigger_momentum_onehop.md
@@ -40,6 +40,12 @@ Resets the velocity of the player after being teleported to the Remote Destinati
 
 Resets the view angles of the player after being teleported to the Remote Destination. Default is true.
 
+>**Fail Teleport** (fail&lt;**choices**&gt;)
+ - **0**: False
+ - **1**: True
+
+Indicates whether this teleport is for failing a level. Default is false.
+
 >**Hold Time (seconds)** (hold&lt;**float**&gt;)
 
 If the player is in this trigger for longer than this (in seconds), teleport them to the most recent progress trigger.


### PR DESCRIPTION
Closes #116 

Updates `trigger_momentum_teleport` with the "fail" boolean property. Also updates all pages that are children of it:
- `trigger_momentum_teleport_progress`
- `trigger_momentum_multihop`
- `trigger_momentum_onehop`

Cleans up all the teleport entity docs to have the same style of listing keyvalues.

Updates the `toggle_*` commands with the fact that the toggles are reset when hitting a fail teleport.

![image](https://user-images.githubusercontent.com/9014762/96510690-c47a6900-1212-11eb-841c-8718cebafef9.png)

![image](https://user-images.githubusercontent.com/9014762/96514203-2db0ab00-1218-11eb-869a-3fd882fabfc3.png)
