### PR TITLE
Tool texture metadata & cvar/cmd/safeguard metadata layout change

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -62,17 +62,16 @@ layout: default
 
         {% comment %} For commands that have an associated safeguard {% endcomment %}
         {% if page.safeguard %}
-          <p class="page__taxonomy">
-            <strong>This command has an associated run safeguard:</strong> 
+          <blockquote>
+            This command has an associated run safeguard:
             <a href="/var/{{ page.safeguard }}"><code>{{ page.safeguard }}</code></a>
-          </p>
-          <br>
+          </blockquote>
         {% endif %}
 
         {% comment %} Show the min/max value of the convar if it exists {% endcomment %}
         {% if page.category == "var" %}
           {% if page.minimum_value or page.maximum_value or page.default_value %}
-            <div class="cvar-minmax-wrapper">
+            <blockquote>
               {% if page.minimum_value %}
                 <div class="cvar-minmax"> <i class="fas fa-fw fa-chevron-down" aria-hidden="true"></i> MIN: {{ page.minimum_value }} </div>
               {% endif %}
@@ -82,32 +81,28 @@ layout: default
               {% if page.default_value %}
                 <div class="cvar-minmax"> <i class="fas fa-fw fa-check" aria-hidden="true"></i> DEFAULT: {{ page.default_value }} </div>
               {% endif %}
-            </div>
+            </blockquote>
           {% endif %}
         {% endif %}
 
         {% comment %} Show the required/optional parameters of the commands if there are any {% endcomment %}
         {% if page.category == "command" %}
           {% if page.required_params or page.optional_params %}
-            <div class="com-wrapper">
+            <blockquote>
               <h1>Parameters:</h1>
               {% if page.required_params %}
-                <div>
-                  <div class="com-params-label"> <i class="fas fa-fw fa-asterisk" aria-hidden="true"></i> REQUIRED: </div>
-                  {% for required_input in page.required_params %}
-                    <div class="com-params">{% if required_input != page.required_params[0] %} | {% endif %} {{ required_input }} </div>
-                  {% endfor %}
-                </div>
+                <div class="com-params-label"> <i class="fas fa-fw fa-asterisk" aria-hidden="true"></i> REQUIRED: </div>
+                {% for required_input in page.required_params %}
+                  <div class="com-params">{% if required_input != page.required_params[0] %} | {% endif %} {{ required_input }} </div>
+                {% endfor %}
               {% endif %}
               {% if page.optional_params %}
-                <div>
-                  <div class="com-params-label"> <i class="fas fa-fw fa-plus" aria-hidden="true"></i> OPTIONAL: </div>
-                  {% for optional_input in page.optional_params %}
-                    <div class="com-params">{% if optional_input != page.optional_params[0] %} | {% endif %} {{ optional_input }} </div>
-                  {% endfor %}
-                </div>
+                <div class="com-params-label"> <i class="fas fa-fw fa-plus" aria-hidden="true"></i> OPTIONAL: </div>
+                {% for optional_input in page.optional_params %}
+                  <div class="com-params">{% if optional_input != page.optional_params[0] %} | {% endif %} {{ optional_input }} </div>
+                {% endfor %}
               {% endif %}
-            </div>
+            </blockquote>
           {% endif %}
         {% endif %}
 

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -111,6 +111,16 @@ layout: default
           {% endif %}
         {% endif %}
 
+        {% comment %} Show the min/max value of the convar if it exists {% endcomment %}
+        {% if page.category == "entity" %}
+          {% if page.tool_texture %}
+            <blockquote>
+              A material for the tool texture shown in the header image can be found in <code>materials/tools/{{ page.tool_texture }}</code>.<br>
+              It is entirely optional and functions identically to the normal trigger texture.
+            </blockquote>
+          {% endif %}
+        {% endif %}
+
         {% include page__taxonomy.html %}
         <p><strong><i class="fas fa-fw fa-edit" aria-hidden="true"></i> <a href="https://github.com/momentum-mod/docs/edit/master/{{ page.path }}">Edit File on GitHub</a></strong></p>
       </footer>

--- a/_posts/entities/2019-09-08-trigger_momentum_teleport.md
+++ b/_posts/entities/2019-09-08-trigger_momentum_teleport.md
@@ -4,8 +4,8 @@ category: entity
 tags:
  - teleport
  - trigger
+tool_texture: trigger_teleport
 ---
-
 
 ----
 ![teleport trigger](/assets/images/trigger_momentum_teleport/momentum_teleport.jpg)

--- a/_posts/entities/2019-09-08-trigger_momentum_timer_checkpoint.md
+++ b/_posts/entities/2019-09-08-trigger_momentum_timer_checkpoint.md
@@ -5,6 +5,7 @@ tags:
  - timer
  - trigger
  - checkpoint
+tool_texture: trigger_checkpoint
 ---
 
 ----

--- a/_posts/entities/2019-09-08-trigger_momentum_timer_stage.md
+++ b/_posts/entities/2019-09-08-trigger_momentum_timer_stage.md
@@ -6,6 +6,7 @@ tags:
  - trigger
  - stage
 ccom_ref: mom_restart_stage
+tool_texture: trigger_stage
 ---
 
 ----

--- a/_posts/entities/2019-09-08-trigger_momentum_timer_start.md
+++ b/_posts/entities/2019-09-08-trigger_momentum_timer_start.md
@@ -5,6 +5,7 @@ tags:
  - timer
  - trigger
  - start
+tool_texture: trigger_start
 ---
 
 ----

--- a/_posts/entities/2019-09-08-trigger_momentum_timer_stop.md
+++ b/_posts/entities/2019-09-08-trigger_momentum_timer_stop.md
@@ -5,6 +5,7 @@ tags:
  - timer
  - trigger
  - stop
+tool_texture: trigger_stop
 ---
 
 ----

--- a/_posts/entities/2019-11-19-trigger_momentum_slide.md
+++ b/_posts/entities/2019-11-19-trigger_momentum_slide.md
@@ -4,6 +4,7 @@ category: entity
 tags:
  - slide
  - trigger
+tool_texture: trigger_slide
 ---
 
 

--- a/_posts/entities/2020-07-13-func_nogrenades.md
+++ b/_posts/entities/2020-07-13-func_nogrenades.md
@@ -10,6 +10,7 @@ tags:
  - rocket jump
  - sticky jump
  - conc
+tool_texture: trigger_nogrenades
 ---
 
 ----

--- a/_posts/entities/2020-09-26-trigger_momentum_catapult.md
+++ b/_posts/entities/2020-09-26-trigger_momentum_catapult.md
@@ -5,6 +5,7 @@ tags:
 - trigger
 - player
 - TF2
+tool_texture: trigger_catapult
 ---
 ----
 ![Catapult trigger texture](/assets/images/trigger_momentum_catapult/catapult.jpg)

--- a/_sass/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/_page.scss
@@ -91,20 +91,12 @@ body {
     background-color: rgba($primary-color, 0.4);
 }
 
-.cvar-minmax-wrapper {
-  margin-bottom: 0.4em;
-}
-
 .cvar-minmax {
   font-size: $type-size-5;
   font-family: $sans-serif-narrow;
   font-weight: bold;
   display: inline;
   padding-right: 2em;
-}
-
-.com-wrapper {
-  margin-bottom: 0.4em;
 }
 
 .com-params-label {


### PR DESCRIPTION
Closes #121 

Adds tool texture metadata for displaying the path to an entities associated tool texture:
![image](https://user-images.githubusercontent.com/9014762/96675772-84a1a780-1320-11eb-8ba5-e23684e1d971.png)

Moves cvar/cmd/safeguard metadata away from a `div` with an associated class to a `blockquote`. The result looks better and fits with the tool texture metadata:
![image](https://user-images.githubusercontent.com/9014762/96675716-60de6180-1320-11eb-917f-f1db51c13f6b.png)
![image](https://user-images.githubusercontent.com/9014762/96675898-e2ce8a80-1320-11eb-9030-26b78e9faebb.png)
