### PR TITLE
Add mom_saveloc_import command

### DIFF
--- a/_posts/commands/2020-05-01-mom_saveloc_current.md
+++ b/_posts/commands/2020-05-01-mom_saveloc_current.md
@@ -3,6 +3,7 @@ title: mom_saveloc_current
 category: command
 tags:
   - saveloc
+  - teleport
 safeguard: mom_run_safeguard_saveloc_tele
 ---
 

--- a/_posts/commands/2020-05-01-mom_saveloc_nav_first.md
+++ b/_posts/commands/2020-05-01-mom_saveloc_nav_first.md
@@ -3,6 +3,7 @@ title: mom_saveloc_nav_first
 category: command
 tags:
   - saveloc
+  - teleport
 safeguard: mom_run_safeguard_saveloc_tele
 ---
 

--- a/_posts/commands/2020-05-01-mom_saveloc_nav_last.md
+++ b/_posts/commands/2020-05-01-mom_saveloc_nav_last.md
@@ -3,6 +3,7 @@ title: mom_saveloc_nav_last
 category: command
 tags:
   - saveloc
+  - teleport
 safeguard: mom_run_safeguard_saveloc_tele
 ---
 

--- a/_posts/commands/2020-05-01-mom_saveloc_nav_next.md
+++ b/_posts/commands/2020-05-01-mom_saveloc_nav_next.md
@@ -3,6 +3,7 @@ title: mom_saveloc_nav_next
 category: command
 tags:
   - saveloc
+  - teleport
 safeguard: mom_run_safeguard_saveloc_tele
 ---
 

--- a/_posts/commands/2020-05-01-mom_saveloc_nav_prev.md
+++ b/_posts/commands/2020-05-01-mom_saveloc_nav_prev.md
@@ -3,6 +3,7 @@ title: mom_saveloc_nav_prev
 category: command
 tags:
   - saveloc
+  - teleport
 safeguard: mom_run_safeguard_saveloc_tele
 ---
 

--- a/_posts/commands/2020-10-31-mom_saveloc_import.md
+++ b/_posts/commands/2020-10-31-mom_saveloc_import.md
@@ -1,0 +1,19 @@
+---
+title: mom_saveloc_import
+category: command
+tags:
+  - saveloc
+required_params: 
+  - Map name
+---
+
+Imports savelocs from another map into the current map.
+Includes parameter autocompletion, which fills with maps that have at least one saveloc.
+
+Does nothing if the player is not in a map.
+
+## Usage Example
+
+> `mom_saveloc_import surf_example` 
+
+Imports `surf_example`'s savelocs into the current map.


### PR DESCRIPTION
Closes #138 

Adds `mom_saveloc_import` command.

Also adds missing "teleport" tags to the saveloc commands that teleport the player.

![image](https://user-images.githubusercontent.com/9014762/97796957-8cd9cc80-1bd5-11eb-94d0-44ca3e762c37.png)
