### PR TITLE
Stage start mark documentation

### DIFF
--- a/_posts/commands/2020-05-01-mom_start_mark_create.md
+++ b/_posts/commands/2020-05-01-mom_start_mark_create.md
@@ -3,8 +3,11 @@ title: mom_start_mark_create
 category: command
 tags:
   - start
+  - stage
   - mark
 ---
 
-Creates a starting mark (a customized starting location/angle) for the current track.
-Only operates when inside a start zone trigger.
+If in a start zone, creates a start mark (a customized starting location/angle) for the current track.
+Start marks are saved with savelocs in `momentum/savedlocs.txt`.
+
+If in a stage zone, creates a temporary start mark which is wiped every run.

--- a/_posts/commands/2020-11-12-mom_stage_mark_clear.md
+++ b/_posts/commands/2020-11-12-mom_stage_mark_clear.md
@@ -1,0 +1,22 @@
+---
+title: mom_stage_mark_clear
+category: command
+tags:
+  - stage
+  - mark
+optional_params:
+  - Stage number
+---
+
+Clears the current stage zone's saved start location if there is one. 
+Optionally accepts a stage number.
+
+## Usage Example
+
+> `mom_start_mark_clear`
+
+Clears the current stage zone's start mark.
+
+> `mom_start_mark_clear 5`
+
+Clears stage 5's start mark.


### PR DESCRIPTION
Closes #150 

- Updates `mom_start_mark_create` to mention creating per-stage start marks.
- Adds `mom_stage_mark_clear` cvar.

![image](https://user-images.githubusercontent.com/9014762/99033339-87fb0e00-252f-11eb-8948-de39e7996756.png)
