### PR TITLE
Note that `mom_restart_stage` does not tele player on linear tracks

### DIFF
--- a/_posts/commands/2019-08-23-mom_restart.md
+++ b/_posts/commands/2019-08-23-mom_restart.md
@@ -9,8 +9,9 @@ optional_params:
 safeguard: mom_run_safeguard_restart
 ---
 
-Restarts the player to the start zone on the current track.
-If no start zone is found, the player will be teleported to the spawn position.
+Restarts the player to the start of the current track; the player is teleported to their start mark if they have one, otherwise they are teleported to the middle of the start zone.
+If there is no start zone, the player will be teleported to the spawn position.
+
 Optionally takes a track number as a parameter, which can be used to get to bonus'.
 
 In the tricksurf gamemode this teleports the player back to their currently tracked trick, if there is any.

--- a/_posts/commands/2020-07-10-mom_restart_stage.md
+++ b/_posts/commands/2020-07-10-mom_restart_stage.md
@@ -11,11 +11,12 @@ ccom_ref: mom_restart
 safeguard: mom_run_safeguard_restart_stage
 ---
 
-Teleports the player to the start of the current stage (the stage zone to be specific) on the current track, if the player is not already in the zone.
-Optionally takes a stage number, or both stage and track numbers as parameters, with the default track being the current track.
+Restarts the player to the start of the current stage on the current track; the player is teleported to their stage start mark if they have one, otherwise they are teleported to the middle of the stage zone.
 
-This command will reset the timer if the desired stage and track is not the one the player is currently on.
+Optionally takes a stage number, or both stage and track numbers as parameters.
+
 Also, it deliberately does nothing in the tricksurf gamemode.
+This command will only reset the timer if the desired stage and track is not the one the player is currently on.
 
 ## Usage Examples
 

--- a/_posts/commands/2020-07-10-mom_restart_stage.md
+++ b/_posts/commands/2020-07-10-mom_restart_stage.md
@@ -15,8 +15,9 @@ Restarts the player to the start of the current stage on the current track; the 
 
 Optionally takes a stage number, or both stage and track numbers as parameters.
 
-Also, it deliberately does nothing in the tricksurf gamemode.
-This command will only reset the timer if the desired stage and track is not the one the player is currently on.
+{:.notice--info}
+This command will only reset the timer if the desired stage and track is not the one the player is currently on. 
+Also, it deliberately does nothing on linear tracks and in the tricksurf gamemode.
 
 ## Usage Examples
 


### PR DESCRIPTION
Closes #146 

- Adds stage mark information to `mom_restart` & `mom_restart_stage`.
- Notes that `mom_restart_stage` does not teleport the player on linear tracks.

![image](https://user-images.githubusercontent.com/9014762/99139124-edf89b80-25ea-11eb-8b55-07b571722dbf.png)

![image](https://user-images.githubusercontent.com/9014762/99139102-d4efea80-25ea-11eb-8e2f-560b2071e4f0.png)
