### PR TITLE
Delete mom_show_changelog doc entry

### DIFF
--- a/_posts/commands/2020-05-01-mom_show_changelog.md
+++ b/_posts/commands/2020-05-01-mom_show_changelog.md
@@ -1,8 +1,0 @@
----
-title: mom_show_changelog
-category: command
-tags:
-  - printout
----
-
-Shows the Momentum Mod changelog.


### PR DESCRIPTION
The last reference i could find for it is from some HTML hud (experiment?) from 2017, it's not in the game currently and the changelog exists in the drawer panel anyways.