### PR TITLE
Fix wrong convar name and broken reference

### DIFF
--- a/_posts/convars/2020-04-30-mom_ghost_online_alpha_override_enable.md
+++ b/_posts/convars/2020-04-30-mom_ghost_online_alpha_override_enable.md
@@ -1,5 +1,5 @@
 ---
-title: mom_ghost_alpha_override_enable
+title: mom_ghost_online_alpha_override_enable
 category: var
 tags:
   - ghost
@@ -8,7 +8,7 @@ tags:
 minimum_value: 0
 maximum_value: 1
 default_value: 1
-cvar_ref: mom_ghost_online_color_alpha_override
+cvar_ref: mom_ghost_online_alpha_override
 ---
 
 Toggle overriding other player's ghost alpha values to the one defined in [`{{ page.cvar_ref }}`](/var/{{ page.cvar_ref }}).


### PR DESCRIPTION
The link to the other cvar is currently broken (See https://docs.momentum-mod.org/var/mom_ghost_online_alpha_override_enable/) and the title also mismatches the file name and the real name as found ingame.