### PR TITLE
Remove unused KVs

### DIFF
--- a/_posts/entities/2020-07-15-trigger_momentum_progress.md
+++ b/_posts/entities/2020-07-15-trigger_momentum_progress.md
@@ -15,14 +15,6 @@ Used for storing a discrete progress number in the player.
 >**Progress Number** (progress_number&lt;**integer**&gt;)
 
  - **-1**: An optional number to assign to this progress trigger, used by filter_momentum_progress.
- 
->**Track Number** (track_number&lt;**integer**&gt;)
-
-The track that this trigger belongs to: 
-
- - **-1**: All Tracks
- - **0**: Main Map
- - **1+**: Bonus Tracks
 
 
 ## Output

--- a/_posts/entities/2020-07-15-trigger_momentum_teleport_progress.md
+++ b/_posts/entities/2020-07-15-trigger_momentum_teleport_progress.md
@@ -14,16 +14,6 @@ Trigger that teleports the player to their last touched `trigger_momentum_progre
 
 ## Keyvalues
 
->**Track Number** (track_number&lt;**integer**&gt;)
-
-The track that this teleport belongs to: 
-
- - **-1**: All Tracks
- - **0**: Main Map
- - **1+**: Bonus Tracks
-
-Default is -1.
-
 >**Remote Destination** (target&lt;**target_destination**&gt;)  
 
 Ignored for this trigger.

--- a/_posts/entities/2020-07-16-trigger_momentum_multihop.md
+++ b/_posts/entities/2020-07-16-trigger_momentum_multihop.md
@@ -12,16 +12,6 @@ Trigger that allows for multiple hops inside of it, and teleports the player if 
 
 ## Keyvalues
 
->**Track Number** (track_number&lt;**integer**&gt;)
-
-The track that this teleport belongs to: 
-
- - **-1**: All Tracks
- - **0**: Main Map
- - **1+**: Bonus Tracks
-
-Default is -1.
-
 >**Remote Destination** (target&lt;**target_destination**&gt;)  
 
 The entity specifying the point to which the player should be teleported.

--- a/_posts/entities/2020-07-16-trigger_momentum_onehop.md
+++ b/_posts/entities/2020-07-16-trigger_momentum_onehop.md
@@ -14,16 +14,6 @@ Trigger that teleports the player after only one entry, or if they stay inside f
 
 ## Keyvalues
 
->**Track Number** (track_number&lt;**integer**&gt;)
-
-The track that this teleport belongs to: 
-
- - **-1**: All Tracks
- - **0**: Main Map
- - **1+**: Bonus Tracks
-
-Default is -1.
-
 >**Remote Destination** (target&lt;**target_destination**&gt;)  
 
 The entity specifying the point to which the player should be teleported.

--- a/_posts/entities/2020-09-26-trigger_catapult.md
+++ b/_posts/entities/2020-09-26-trigger_catapult.md
@@ -81,26 +81,6 @@ Use in conjunction with the "OnCatapulted" output to create velocity checking tr
 Only works when "Use threshold check" is enabled.
 Default is off; 0.
 
-> OnThink (OnThink&lt;**integer**&gt;) 
-
-If set to 1, the trigger fires on an interval set by "Interval".
-Default is off; 0.
-
-> Interval (Interval&lt;**float**&gt;) 
-
-Time in seconds between updates when "OnThink" is set to 1.
-Default is 1.
-
-> Every tick (EveryTick&lt;**integer**&gt;) 
-
-Trigger fires every tick if set to 1.
-Default is off; 0.
-
-> Height offset (heightOffset&lt;**float**&gt;) 
-
-Offsets the origin of the player vertically, in units.
-Default legacy value is 32 units from TF2.
-
 ## Output
 
 > OnCatapulted(**void**)

--- a/_posts/entities/2020-09-26-trigger_catapult.md
+++ b/_posts/entities/2020-09-26-trigger_catapult.md
@@ -15,9 +15,14 @@ A trigger volume that launches the player at a specified speed towards a target 
 
 ## Keyvalues
 
-> Player speed (playerSpeed&lt;**float**&gt;) 
+> Player speed (playerspeed&lt;**float**&gt;) 
 
-The base speed to launch the player at in units per second.
+Speed at which to launch the players (u/sec).
+Default is 450.
+
+> Physics speed (physicsspeed&lt;**float**&gt;)
+
+Speed at which to launch physics objects (u/sec).
 Default is 450.
 
 > Use threshold check (useThresholdCheck&lt;**integer**&gt;)
@@ -80,6 +85,24 @@ If set to 1, the trigger only checks the velocity of the touching object and doe
 Use in conjunction with the "OnCatapulted" output to create velocity checking triggers. 
 Only works when "Use threshold check" is enabled.
 Default is off; 0.
+
+## Input
+
+> SetPlayerSpeed(**float**)
+
+Set the speed to launch the player at (field `playerSpeed`).
+
+> SetPhysicsSpeed(**float**)
+
+Set the speed to launch the physics objects at (field `physicsspeed`).
+
+> SetLaunchTarget(**target_entity_name**)
+
+Set the entity to try hit when launched (field `launchTarget`).
+
+> SetExactVelocityChoiceType(**integer**)
+
+Set the Exact Solution Method (field `exactVelocityChoiceType`).
 
 ## Output
 

--- a/_posts/entities/2020-12-08-trigger_teleport.md
+++ b/_posts/entities/2020-12-08-trigger_teleport.md
@@ -17,16 +17,6 @@ A [trigger](https://developer.valvesoftware.com/wiki/Triggers){:target="blank"} 
 
 ## Keyvalues
 
->**Track Number** (track_number&lt;**integer**&gt;)
-
-The track that this teleport belongs to: 
-
- - **-1**: All Tracks
- - **0**: Main Map
- - **1+**: Bonus Tracks
-
-Default is -1.
-
 >**Remote Destination** (target&lt;**target_destination**&gt;)  
 
 The entity specifying the point to which the player should be teleported.

--- a/_posts/entities/2021-01-06-trigger_reversespeed.md
+++ b/_posts/entities/2021-01-06-trigger_reversespeed.md
@@ -14,14 +14,6 @@ A [trigger](https://developer.valvesoftware.com/wiki/Triggers){:target="blank"} 
 
 ## Keyvalues
 
->**Track Number** (track_number&lt;**integer**&gt;)
-
-The track that this zone belongs to:
-
- - **-1**: All Tracks **(Default)**
- - **0**: Main Map
- - **1+**: Bonus Tracks
-
 >**Reverse horizontal speed** (ReverseHorizontal&lt;**integer**&gt;)
 
  Whether or not the trigger reverses the player's horizontal (x/y axis) speed:

--- a/_posts/entities/2021-01-06-trigger_setspeed.md
+++ b/_posts/entities/2021-01-06-trigger_setspeed.md
@@ -16,14 +16,6 @@ If you want to send the player in a specific direction, use a [catapult](/entity
 
 ## Keyvalues
 
->**Track Number** (track_number&lt;**integer**&gt;)
-
-The track that this zone belongs to:
-
- - **-1**: All Tracks **(Default)**
- - **0**: Main Map
- - **1+**: Bonus Tracks
-
 >**Keep horizontal speed** (KeepHorizontalSpeed&lt;**integer**&gt;)
 
  Whether or not the trigger affects the player's horizontal (x/y axis) speed:

--- a/_posts/entities/2021-09-26-trigger_stick_explosive.md
+++ b/_posts/entities/2021-09-26-trigger_stick_explosive.md
@@ -27,18 +27,18 @@ Defaults to 0.
 
 ## Input
 
->input Stick(**void**)
+> Stick(**void**)
 
 Sticks all explosives in this area.
 
->input Unstick(**void**)
+> Unstick(**void**)
 
 Unsticks all explosives in this area.
 
->input Explode(**void**)
+> Explode(**void**)
 
 Explodes all explosives in this area.
 
->input Fizzle(**void**)
+> Fizzle(**void**)
 
 Fizzles all explosives in this area.


### PR DESCRIPTION
When baselining our triggers I had to change bases on a lot of em, causing them to use the track number (as it is from momentum's base trigger).

Also some functionality was lost in the `trigger_catapult` baselining with P2CE's, and new inputs were not added.