### PR TITLE
Add mom_hud_speedometer_fps cvar

### DIFF
--- a/_posts/convars/2021-12-10-mom_hud_speedometer_fps.md
+++ b/_posts/convars/2021-12-10-mom_hud_speedometer_fps.md
@@ -4,8 +4,6 @@ category: var
 tags:
   - hud
   - speedometer
-minimum_value: 1
-maximum_value: 0 (Uncapped)
 default_value: 120
 ---
 

--- a/_posts/convars/2021-12-10-mom_hud_speedometer_fps.md
+++ b/_posts/convars/2021-12-10-mom_hud_speedometer_fps.md
@@ -1,0 +1,15 @@
+---
+title: mom_hud_speedometer_fps
+category: var
+tags:
+  - hud
+  - speedometer
+minimum_value: 1
+maximum_value: 0 (Uncapped)
+default_value: 120
+---
+
+{:.notice--info}
+Setting this value to `0` removes the limit (uncapped)
+
+Controls the rate at which the axis speedometers (absolute, horizontal, and vertical) update.


### PR DESCRIPTION
Closes https://github.com/momentum-mod/docs/issues/224

Default value of `120` referenced from the in-game default:
![image](https://user-images.githubusercontent.com/7349732/145611022-a2fb6434-b66c-4b16-96c5-4addda36668b.png)

Maximum value is displayed correctly on the site:
![image](https://user-images.githubusercontent.com/7349732/145611282-f7d52a51-83ac-4ebf-b300-304e614ee566.png)