### PR TITLE
Add NetBeans build guide

### DIFF
--- a/_posts/guides/2021-12-10-guide_netbeans_linux_build.md
+++ b/_posts/guides/2021-12-10-guide_netbeans_linux_build.md
@@ -1,0 +1,63 @@
+---
+title: NetBeans Linux Build Guide
+permalink: /guide/netbeans-linux-build/
+category: guide
+tags:
+  - build
+  - linux
+toc: true
+toc_sticky: true
+---
+
+This guide will offer a high-level overview of compiling the mod on Linux using the [NetBeans IDE](https://netbeans.apache.org/).
+
+## Initial Setup
+
+### With sudo
+
+If project already has been previously compiled with `sudo`:
+1. `cd` to `game/mp/`
+2. run `sudo chown -R $(whoami):$(whoami) .` where `$(whoami)` _should_ be your local user (not `root`)
+
+{:.notice--info}
+These steps can also be combined into a single command like so: `sudo chown -R $(whoami):$(whoami) game/mp/`
+
+### Without sudo
+
+1. Replace `groups=sudo` with `groups=<username>` in `/etc/schroot/chroot.d/steamrt_scout_i386.conf` where `<username>` is your local user (not `root`)
+2. `cd` to `game/mp/src/`
+3. Execute `./creategameprojects` (`chmod +x` if it cannot be run for some reason)
+4. Run `schroot --chroot steamrt_scout_i386 -- make -f games.mak` to compile
+
+{:.notice--info}
+Step 1 can also be completed with something like `sed -i "s/groups=sudo/groups=$(whoami)/g" /etc/schroot/chroot.d/steamrt_scout_i386.conf`
+
+## NetBeans Configuration
+
+{:.notice--info}
+The following steps require the configuration steps from above ([Initial Setup](#initial-setup)) except for compiling
+
+1. Install NetBeans (netbeans package)
+2. Navigate to `Tools` -> `Plugins`  
+	- Navigate to `Settings` -> `Check NetBeans 8.2 Plugin Portal`  
+	- Select `Available Plugins` -> `Install C/C++`  
+3. Navigate to `Tools` -> `Options`  
+	- Navigate to `Editor` -> `Formatting`  
+		- `Language`: `All Languages`  
+		- `Category`: `Tabs and Indents`  
+		- `Expand Tabs to Spaces`: `Check`  
+		- `Number of Spaces per Indent`: `4`  
+		- `Tab Size`: `4`  
+		- `Right Margin`: `120`  
+	- Navigate to `Editor` -> `On Save`  
+		- `Language`: `All Languages`  
+		- `Reformat`: `None`  
+		- `Remove Trailing Whitespace From`: `Modified Lines Only`  
+4. Navigate to `File` -> `Open Project`  
+	- Select `game/mp/src`  
+5. Navigate to `File` -> Select `Project Properties`  
+	- Under `General` -> Select `Add Source Folder` -> Select `game/mp/src`  
+	- Under `Run` -> Configure `Run Directory`: `<path to MomentumDev>` (Server and Client configuration)  
+	- Under `Run` -> Configure `Run Command` : `<change run parameters to liking>` (Server and Client configuration)  
+6. Select `Run` -> `Build Project (F11)`  
+7. Select `Debug` -> `Debug Project (F5)` (`Run` -> `Run Project (F6)` does not work for some reason)  


### PR DESCRIPTION
Closes https://github.com/momentum-mod/docs/issues/64; relates to https://github.com/momentum-mod/game/pull/894 (mentioned in the `docs` issue)

Adds a new guide post with the steps outlined in the NetBeans build PR