### PR TITLE
Add information on ammo, weapons, and powerups.

### DIFF
--- a/content/docs/entity/momentum_pickup_ammo.md
+++ b/content/docs/entity/momentum_pickup_ammo.md
@@ -1,0 +1,26 @@
+---
+title: momentum_pickup_ammo
+categories:
+  - entity
+tags:
+ - point entity
+ - weapons
+ - ammo
+---
+
+This entity can be used to give the player ammo.
+
+## Keyvalues
+
+>**Reset Time** (ResetTime&lt;**float**&gt;)
+
+The amount of time in seconds before a weapon can be picked up again. If this value is negative, then the spawner will only give a weapon once.
+
+>**Ammo Name** (AmmoName&lt;**string**&gt;)
+
+Name of the ammo type to give the player. Must be one of the names listed on [Ammo System](/guide/ammo-system/).
+
+>**Pickup Ammo** (PickupAmmo&lt;**integer**&gt;)
+
+Amount of ammo to give the player for the specified ammo type. If the value is negative, it gives the player infinite ammo for that weapon. If the value is positive, the player is given that amount of ammo, up to the ammo limit.
+

--- a/content/docs/entity/momentum_powerup_damage_boost.md
+++ b/content/docs/entity/momentum_powerup_damage_boost.md
@@ -1,0 +1,22 @@
+---
+title: momentum_powerup_damage_boost
+categories:
+  - entity
+tags:
+ - point entity
+ - powerups
+ - defrag
+---
+
+This entity gives the player the damage boost effect in defrag.
+
+## Keyvalues
+
+>**Reset Time** (ResetTime&lt;**float**&gt;)
+
+The amount of time in seconds before the powerup can be picked up again. If this value is negative, then the powerup can only be picked up once.
+
+>**Damage Boost Time** (DamageBoostTime&lt;**float**&gt;)
+
+The amount of time in seconds for the damage boost effect to last. If this value is negative, then the effect is indefinite and will last until changed to be finite or 0.
+

--- a/content/docs/entity/momentum_powerup_haste.md
+++ b/content/docs/entity/momentum_powerup_haste.md
@@ -1,0 +1,22 @@
+---
+title: momentum_powerup_haste
+categories:
+  - entity
+tags:
+ - point entity
+ - powerups
+ - defrag
+---
+
+This entity gives the player the haste effect in defrag.
+
+## Keyvalues
+
+>**Reset Time** (ResetTime&lt;**float**&gt;)
+
+The amount of time in seconds before the powerup can be picked up again. If this value is negative, then the powerup can only be picked up once.
+
+>**Haste Time** (HasteTime&lt;**float**&gt;)
+
+The amount of time in seconds for the haste effect to last. If this value is negative, then the effect is indefinite and will last until changed to be finite or 0.
+

--- a/content/docs/entity/momentum_weapon_spawner.md
+++ b/content/docs/entity/momentum_weapon_spawner.md
@@ -1,0 +1,24 @@
+---
+title: momentum_weapon_spawner 
+category: entity
+tags:
+ - point entity
+ - weapons
+---
+
+This entity can be used to give the player a weapon and ammo for that weapon.
+
+## Keyvalues
+
+>**Reset Time** (ResetTime&lt;**float**&gt;)
+
+The amount of time in seconds before a weapon can be picked up again. If this value is negative, then the spawner will only give a weapon once.
+
+>**Weapon Name** (WeaponName&lt;**string**&gt;)
+
+Name of the weapon to give the player. Must be one of the names listed on [Weapon System](/guide/weapon-system/).
+
+>**Pickup Ammo** (PickupAmmo&lt;**integer**&gt;)
+
+Amount of ammo to give the player for the weapon given by the spawner. If the value is negative, it gives the player infinite ammo for that weapon. If the value is positive, and the player has less than that amount of ammo, it sets the player's ammo to that amount. Otherwise it only gives 1 ammo. If the value is 0, then it has no effect.
+

--- a/content/docs/guide/mapping/ammo_system.md
+++ b/content/docs/guide/mapping/ammo_system.md
@@ -1,0 +1,86 @@
+---
+title: Ammo System
+categories:
+  - guide
+tags:
+  - ammo
+  - mapping
+---
+
+The ammo system allows mappers to control how many shots the player can fire from weapons that use ammo. All defrag weapons, the RJ rocket launcher, the sticky bomb launcher, and concs can be controlled with separate ammo types. The default state for the player is infinite ammo, but the player's ammo can be changed with player IO inputs and entities. Additionally, an ammo limit can be set that doesn't allow the player to have more than a certain amount.
+
+# Pickup Entities
+
+The [`momentum_pickup_ammo`](/entity/momentum_pickup_ammo) entity can also give the player ammo. The key `AmmoName` controls the type of ammo. It takes a string which is one of these names:
+
+```
+"rockets"
+"stickybombs"
+"concs"
+"grenades"
+"bullets"
+"shells"
+"cells"
+"rails"
+"plasma"
+"bfg_rockets"
+```
+
+The entity also takes a `PickupAmmo` key which controls how much ammo the player gets. A negative value gives the player infinite ammo. If the player already has infinite ammo, this entity does nothing when the player picks it up.
+
+## Ammo from Weapon Spawners
+
+The [`momentum_weapon_spawner`](/entity/momentum_weapon_spawner) entity gives a certain amount of ammo, controlled by the `PickupAmmo` key. If the value is negative, it gives the player infinite ammo for that weapon. If the value is positive, and the player has less than that amount of ammo, it sets the player's ammo to that amount. Otherwise it only gives 1 ammo. If the value is 0, then it has no effect.
+
+# Player Inputs
+
+The mapper can use inputs on the player to set, add, or subtract the player's ammo. The mapper can change only one type of ammo at a time, or all the ammo types at once. The following inputs control the player's ammo. Which weapon uses which ammo type is listed next to them, but some ammo types aren't currently used by any weapons.
+
+```
+SetAmmo          <- all ammo types
+SetRockets       <- rocket launcher (RJ and DF)
+SetStickyBombs   <- sticky bomb launcher
+SetConcs         <- concs
+SetGrenades      <- DF grenade launcher
+SetBullets
+SetShells
+SetCells
+SetRails
+SetPlasma        <- DF plasma gun
+SetBfgRockets    <- DF BFG
+
+AddAmmo          <- all ammo types
+AddRockets       <- rocket launcher (RJ and DF)
+AddStickyBombs   <- sticky bomb launcher
+AddConcs         <- concs
+AddGrenades      <- DF grenade launcher
+AddBullets
+AddShells
+AddCells
+AddRails
+AddPlasma        <- DF plasma gun
+AddBfgRockets    <- DF BFG
+```
+
+The player can be in one of three states with ammo:
+
+1. Negative ammo - Can shoot an infinite amount of shots. This is the default.
+2. Positive ammo - Can shoot, each shot will take 1 ammo.
+3. Zero ammo     - Out of ammo, cannot shoot.
+
+For example, to give infinite rockets, you would use:
+
+`SetRockets -1`
+
+To add 30 plasma bolts, you would use:
+
+`AddPlasma 30`
+
+To take away 2 sticky bombs, you would use:
+
+`AddStickyBombs -2`
+
+## Ammo Limit
+
+By default, the player has a limit of 200 on the maximum amount of ammo they can carry of any type. This can be changed with the `SetAmmoLimit` input, where a limit of -1 means no limit. The ammo limit does *not* prevent the player from carrying infinite ammo, it only applies when the player's ammo is finite.
+

--- a/content/docs/guide/mapping/giving_players_powerups.md
+++ b/content/docs/guide/mapping/giving_players_powerups.md
@@ -1,0 +1,19 @@
+---
+title: Giving Players Powerups
+categories:
+  - guide
+tags:
+  - defrag
+  - mapping
+  - powerups
+---
+
+Two powerups are implemented: Haste and Damage Boost. They can be given or removed with these inputs:
+
+`SetHaste (time in seconds)`
+
+`SetDamageBoost (time in seconds)`
+
+If time = 0, the effect will be removed. If time < 0, then the effect will last indefinitely until removed.
+
+There are also powerup entities: [`momentum_powerup_haste`](/entity/momentum_powerup_haste) and [`momentum_powerup_damage_boost`](/entity/momentum_powerup_damage_boost). They both take a `ResetTime` key like the weapon spawner entity. The haste powerup takes a `HasteTime` key, and the damage boost powerup takes a `DamageBoostTime` key. They are both specified in seconds the same way as the inputs.

--- a/content/docs/guide/mapping/weapon_system.md
+++ b/content/docs/guide/mapping/weapon_system.md
@@ -1,0 +1,44 @@
+---
+title: Weapon System
+categories:
+  - guide
+tags:
+  - mapping
+  - weapons
+---
+
+The weapon system allows mappers to give and remove a players weapons via entity logic.
+
+# Weapon Spawner Entity
+
+The [`momentum_weapon_spawner`](/entity/momentum_weapon_spawner) entity can be used to give the player a weapon. The entity currently takes a weapon entity name in the `WeaponName` key. The following weapon names can be used:
+
+```
+"weapon_momentum_pistol"
+"weapon_momentum_shotgun"
+"weapon_momentum_machinegun"
+"weapon_momentum_sniper"
+"weapon_momentum_grenade"
+"weapon_momentum_concgrenade"
+"weapon_knife"
+"weapon_momentum_rocketlauncher"
+"weapon_momentum_stickylauncher"
+"weapon_momentum_df_plasmagun"
+"weapon_momentum_df_rocketlauncher"
+"weapon_momentum_df_bfg"
+"weapon_momentum_df_grenadelauncher"
+```
+
+The entity also has a `ResetTime` key, which is the amount of time in seconds before a weapon can be picked up again. If this value is negative, then the spawner will only give a weapon once. Once we implement a save state system on map reset, this entity should reset along with that, but right now the only way to reset the spawner when it's in this state is to reload the map.
+
+# Inputs
+
+Weapons can be enabled or disabled using the following inputs:
+
+```
+GiveWeapon (weapon name)
+RemoveWeapon (weapon name)
+```
+
+This input uses the same entity names given above for the weapon spawner entity. Only weapons that the player can normally get in the gamemode can be controlled this way. For example, you cannot give the player conc grenades in RJ.
+

--- a/content/docs/var/mom_df_autoswitch.md
+++ b/content/docs/var/mom_df_autoswitch.md
@@ -1,0 +1,12 @@
+---
+title: mom_df_autoswitch
+categories:
+  - var
+tags:
+  - weapons
+minimum_value: 0
+maximum_value: 2
+default_value: 1
+---
+
+Controls switching behavior on weapon pickup. The default value of 1 causes autoswitch to happen on every weapon pickup. 0 disables autoswitch, and 2 only switches if the player gets a weapon that wasn't already enabled.


### PR DESCRIPTION
Adds information for entities `momentum_powerup_damage_boost`, `momentum_powerup_haste`, `momentum_weapon_spawner`, `momentum_pickup_ammo`, cvar `mom_df_autoswitch`, and the various associated player inputs.