### PR TITLE
fix Creating Tricks Documentation : Updated link  directing to guide on basic surfing

### DIFF
--- a/content/docs/guide/zoning/creating_tricks.md
+++ b/content/docs/guide/zoning/creating_tricks.md
@@ -20,7 +20,7 @@ Creating tricks and tricksurf as a whole is in the initial phase of implementati
 
 To follow this guide you should:
 
-- Know the basics of using the zoning tools (see the [guide on basic zoning](guide/basic-zoning))
+- Know the basics of using the zoning tools (see the [guide on basic zoning](/guide/zoning/basic_zoning/))
 - Be on Momentum 0.8.6+
 - Be running Momentum in mapping mode via the `-mapping` launch parameter
 - Have the developer console enabled and be able to use it


### PR DESCRIPTION
Changed 'guide/basic-zoning' to '/guide/zoning/basic_zoning' to fix 404 error